### PR TITLE
Set RUSTUP_HOME in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,4 @@ ARG RUST_VERSION=stable
 RUN rustup install --profile minimal $RUST_VERSION
 
 ENV PATH="/root/.cargo/bin:${PATH}"
+ENV RUSTUP_HOME="/root/.rustup"


### PR DESCRIPTION
Some environments (GitHub Actions for example) may fiddle with the HOME variable which leads to rustup failing .